### PR TITLE
fix: lock numpy to 1.26.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-rich
+beautifulsoup4
+numpy==1.26.4
 pandas
 requests
-beautifulsoup4
+rich
 spacy


### PR DESCRIPTION
spacy is not compatible with numpy 2.x, see:
https://github.com/explosion/spaCy/issues/13528 and thus the CI fails locking numpy to latest 1.x release fixes this problem